### PR TITLE
Options

### DIFF
--- a/doxray.js
+++ b/doxray.js
@@ -65,6 +65,7 @@ Doxray.prototype.parse = function( src, options ) {
     var fileContents, docs, code, convertedDocs, ext, regex;
     // Get the file extension for src so we know which regex to use.
     ext = require('./utils.js').getCommentType( singleSrc );
+    // get the regex for that extension, or fallback to CSS regex.
     regex = options.regex[ ext ] || options.regex.css;
     fileContents = require('./utils.js').getFileContents( singleSrc, regex );
     docs = require('./utils.js').parseOutDocs( fileContents, regex );

--- a/doxray.js
+++ b/doxray.js
@@ -62,12 +62,13 @@ Doxray.prototype.run = function( src, options, callback ) {
 Doxray.prototype.parse = function( src, options ) {
   var parsed = [];
   src.forEach(function( singleSrc ) {
-    var fileContents, docs, code, convertedDocs, ext;
+    var fileContents, docs, code, convertedDocs, ext, regex;
     // Get the file extension for src so we know which regex to use.
     ext = require('./utils.js').getCommentType( singleSrc );
-    fileContents = require('./utils.js').getFileContents( singleSrc, options.regex[ ext ] );
-    docs = require('./utils.js').parseOutDocs( fileContents, options.regex[ ext ] );
-    code = require('./utils.js').parseOutCode( fileContents, options.regex[ ext ] );
+    regex = options.regex[ ext ] || options.regex.css;
+    fileContents = require('./utils.js').getFileContents( singleSrc, regex );
+    docs = require('./utils.js').parseOutDocs( fileContents, regex );
+    code = require('./utils.js').parseOutCode( fileContents, regex );
     if ( docs.length === 0 ) {
       convertedDocs = [];
     } else {

--- a/test/index.js
+++ b/test/index.js
@@ -64,12 +64,6 @@ describe('doxray.js, core methods', function() {
     it('should respect custom regex patterns in options while retaining defaults', function () {
       var options = {
         regex: {
-          html: {
-            opening: /^<!--\s*doxray[^\n]*\n/m,
-            closing: /-->/,
-            comment: /^<!--\s*doxray(?:[^-]|[\r\n]|-[^-])*-->/gm,
-            ignore: /^<!--\s*ignore-doxray[\s\S]*/gm
-          },
           css: {
             opening: /^\/\*\s*@docs[^\n]*\n/m,
             closing: /\*\//,
@@ -77,10 +71,15 @@ describe('doxray.js, core methods', function() {
           }
         }
       };
-      var docs = doxray.run('test/custom-comment-regex-test.css', options);
+      var css = doxray.run('test/custom-comment-regex-test.css', options);
       assert.deepEqual(
-        docs.patterns[0].prop1,
+        css.patterns[0].prop1,
         'Comment one'
+      );
+      var html = doxray.run('test/test.html', options);
+      assert.deepEqual(
+        html.patterns[0].label,
+        'heading one'
       );
     });
 
@@ -297,6 +296,15 @@ describe('utils.js', function() {
     it('should return an options object', function () {
       var options = {
         regex: {
+          css: {
+            opening: /^\/\*\s*@docs[^\n]*\n/m,
+            closing: /\*\//,
+            comment: /^\/\*\s*@docs[^*]*\*+(?:[^/*][^*]*\*+)*\//gm
+          }
+        }
+      };
+      var expected =  {
+        regex: {
           html: {
             opening: /^<!--\s*doxray[^\n]*\n/m,
             closing: /-->/,
@@ -309,7 +317,7 @@ describe('utils.js', function() {
             comment: /^\/\*\s*@docs[^*]*\*+(?:[^/*][^*]*\*+)*\//gm
           }
         }
-      };
+      }
       var transformedOptions = require('../utils.js').handleOptions(options);
       assert.deepEqual(
         transformedOptions,
@@ -317,7 +325,7 @@ describe('utils.js', function() {
           jsFile: undefined,
           jsonFile: undefined,
           processors: doxray.processors,
-          regex: options.regex
+          regex: expected.regex
         }
       );
     });

--- a/test/index.js
+++ b/test/index.js
@@ -61,9 +61,15 @@ describe('doxray.js, core methods', function() {
       );
     });
 
-    it('should respect custom regex patterns in options', function () {
+    it('should respect custom regex patterns in options while retaining defaults', function () {
       var options = {
         regex: {
+          html: {
+            opening: /^<!--\s*doxray[^\n]*\n/m,
+            closing: /-->/,
+            comment: /^<!--\s*doxray(?:[^-]|[\r\n]|-[^-])*-->/gm,
+            ignore: /^<!--\s*ignore-doxray[\s\S]*/gm
+          },
           css: {
             opening: /^\/\*\s*@docs[^\n]*\n/m,
             closing: /\*\//,
@@ -291,6 +297,12 @@ describe('utils.js', function() {
     it('should return an options object', function () {
       var options = {
         regex: {
+          html: {
+            opening: /^<!--\s*doxray[^\n]*\n/m,
+            closing: /-->/,
+            comment: /^<!--\s*doxray(?:[^-]|[\r\n]|-[^-])*-->/gm,
+            ignore: /^<!--\s*ignore-doxray[\s\S]*/gm
+          },
           css: {
             opening: /^\/\*\s*@docs[^\n]*\n/m,
             closing: /\*\//,
@@ -379,8 +391,8 @@ describe('utils.js', function() {
 
     it('should return the correct comment type based on the file extension', function() {
       assert.equal( require('../utils.js').getCommentType('test.css'), 'css' );
-      assert.equal( require('../utils.js').getCommentType('test.less'), 'css' );
-      assert.equal( require('../utils.js').getCommentType('test.less'), 'css' );
+      assert.equal( require('../utils.js').getCommentType('test.less'), 'less' );
+      assert.equal( require('../utils.js').getCommentType('test.njk'), 'njk' );
       assert.equal( require('../utils.js').getCommentType('test.html'), 'html' );
     });
 

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+<!-- doxray
+  label: heading one
+-->
+<h1>My special  test header</h1>
+</body>
+</html>

--- a/utils.js
+++ b/utils.js
@@ -103,17 +103,6 @@ utils.getFileContents = function( src, regex ) {
 utils.getCommentType = function( src ) {
   var path = require('path');
   var ext = path.extname( src ).substring( 1 );
-  switch ( ext ) {
-    case 'css':
-    case 'less':
-      ext = 'css';
-      break;
-    case 'html':
-      ext = 'html';
-      break;
-    default:
-      ext = 'css';
-  }
   return ext;
 };
 

--- a/utils.js
+++ b/utils.js
@@ -14,14 +14,20 @@ utils.handleSrc = function( src ) {
 };
 
 utils.handleOptions = function( options ) {
+  var regexMerge = Object.assign( {}, require('./doxray.js').prototype.regex );
   if ( typeof options !== 'object' ) {
     options = {};
+  }
+  if (options.regex) {
+    Object.keys(options.regex).forEach( function( language ) {
+      regexMerge[ language ] = options.regex[ language ];
+    });
   }
   return {
     jsFile: options.jsFile,
     jsonFile: options.jsonFile,
     processors: options.processors || require('./doxray.js').prototype.processors,
-    regex: options.regex || require('./doxray.js').prototype.regex
+    regex: regexMerge
   };
 };
 


### PR DESCRIPTION
Fixes #25 

Changes:
- `utils.getCommentType()` returns the extension, without attempting to convert related languages
- `Doxray.prototype.parse()` looks for regex based on extension, or falls back to CSS if no extension-based regex is available (same end result for languages with existing support)
- `utils.handleOptions()` will merge new languages into the default regex map, so it's possible to set a new language option without overriding the default options