### PR TITLE
More flexible default regex

### DIFF
--- a/doxray.js
+++ b/doxray.js
@@ -11,16 +11,16 @@ var Doxray = function() {};
 
 Doxray.prototype.regex = {
   html: {
-    opening: /^<!--\s*doxray[^\n]*\n/m,
+    opening: /<!--\s*doxray[^\n]*\n/m,
     closing: /-->/,
-    comment: /^<!--\s*doxray(?:[^-]|[\r\n]|-[^-])*-->/gm,
-    ignore: /^<!--\s*ignore-doxray[\s\S]*/gm
+    comment: /<!--\s*doxray(?:[^-]|[\r\n]|-[^-]|--[^>])*-->/gm,
+    ignore: /<!--\s*ignore-doxray[\s\S]*/gm
   },
   css: {
-    opening: /^\/\*\s*doxray[^\n]*\n/m,
+    opening: /\/\*\s*doxray[^\n]*\n/m,
     closing: /\*\//,
-    comment: /^\/\*\s*doxray[^*]*\*+(?:[^/*][^*]*\*+)*\//gm,
-    ignore: /^\/\*\s*ignore-doxray[\s\S]*/gm
+    comment: /\/\*\s*doxray[^*]*\*+(?:[^/*][^*]*\*+)*\//gm,
+    ignore: /\/\*\s*ignore-doxray[\s\S]*/gm
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -306,10 +306,10 @@ describe('utils.js', function() {
       var expected =  {
         regex: {
           html: {
-            opening: /^<!--\s*doxray[^\n]*\n/m,
+            opening: /<!--\s*doxray[^\n]*\n/m,
             closing: /-->/,
-            comment: /^<!--\s*doxray(?:[^-]|[\r\n]|-[^-])*-->/gm,
-            ignore: /^<!--\s*ignore-doxray[\s\S]*/gm
+            comment: /<!--\s*doxray(?:[^-]|[\r\n]|-[^-]|--[^>])*-->/gm,
+            ignore: /<!--\s*ignore-doxray[\s\S]*/gm
           },
           css: {
             opening: /^\/\*\s*@docs[^\n]*\n/m,

--- a/test/index.js
+++ b/test/index.js
@@ -79,7 +79,7 @@ describe('doxray.js, core methods', function() {
       var html = doxray.run('test/test.html', options);
       assert.deepEqual(
         html.patterns[0].label,
-        'heading one'
+        'heading ---- one'
       );
     });
 

--- a/test/test.css
+++ b/test/test.css
@@ -12,9 +12,9 @@
 
 /* Another comment */
 
-/* doxray
+    /* doxray
     prop1: Comment two
-*/
+    */
 
 .test2 {
     color: green;

--- a/test/test.html
+++ b/test/test.html
@@ -7,9 +7,9 @@
   <title>Document</title>
 </head>
 <body>
-<!-- doxray
-  label: heading one
--->
-<h1>My special  test header</h1>
+  <!-- doxray
+    label: heading one
+  -->
+  <h1>My special  test header</h1>
 </body>
 </html>

--- a/test/test.html
+++ b/test/test.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <!-- doxray
-    label: heading one
+    label: heading ---- one
   -->
   <h1>My special  test header</h1>
 </body>

--- a/utils.js
+++ b/utils.js
@@ -19,7 +19,7 @@ utils.handleOptions = function( options ) {
     options = {};
   }
   if (options.regex) {
-    Object.keys(options.regex).forEach( function( language ) {
+    Object.keys( options.regex ).forEach( function( language ) {
       regexMerge[ language ] = options.regex[ language ];
     });
   }


### PR DESCRIPTION
New regex allows:
- doc opening/closing markers don't have to be flush left
- html comments can contain multiple `-----` in a row